### PR TITLE
feat(desktop): 完善窗口拖拽和最大化功能，优化macOS标题栏样式

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,11 @@
   "identifier": "default",
   "description": "Default desktop capability for the NewMd shell.",
   "windows": ["main"],
-  "permissions": ["core:default", "dialog:default", "core:window:allow-set-title"]
+  "permissions": [
+    "core:default",
+    "dialog:default",
+    "core:window:allow-set-title",
+    "core:window:allow-start-dragging",
+    "core:window:allow-toggle-maximize"
+  ]
 }

--- a/src-tauri/gen/schemas/capabilities.json
+++ b/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default desktop capability for the NewMd shell.","local":true,"windows":["main"],"permissions":["core:default","dialog:default","core:window:allow-set-title"]}}
+{"default":{"identifier":"default","description":"Default desktop capability for the NewMd shell.","local":true,"windows":["main"],"permissions":["core:default","dialog:default","core:window:allow-set-title","core:window:allow-start-dragging","core:window:allow-toggle-maximize"]}}

--- a/src/app/components/AppTitleBar.svelte
+++ b/src/app/components/AppTitleBar.svelte
@@ -32,25 +32,71 @@
 
   let isMac = false;
   let isWin = false;
+  let isFullscreen = false;
+  let unlistenResized: (() => void) | null = null;
 
   onMount(() => {
     isMac = navigator.userAgent.includes('Mac');
     isWin = navigator.userAgent.includes('Win');
+    
+    let isDestroyed = false;
+
+    if (desktopEnabled) {
+      import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
+        if (isDestroyed) return;
+        const appWindow = getCurrentWindow();
+        
+        // 初始化状态
+        appWindow.isFullscreen().then(fullscreen => {
+          if (!isDestroyed) isFullscreen = fullscreen;
+        });
+
+        // 监听窗口改变事件
+        appWindow.onResized(async () => {
+          if (!isDestroyed) isFullscreen = await appWindow.isFullscreen();
+        }).then(unlisten => {
+          if (isDestroyed) {
+            unlisten();
+          } else {
+            unlistenResized = unlisten;
+          }
+        });
+      });
+    }
+
+    return () => {
+      isDestroyed = true;
+      if (unlistenResized) {
+        unlistenResized();
+      }
+    };
   });
 
   async function handleDrag(e: MouseEvent) {
     if (!desktopEnabled || e.buttons !== 1) return;
-    if (isMac) return; // Mac let CSS handle it natively
 
-    // 只在拖动区域触发，避免影响内部按钮点击
     const target = e.target as HTMLElement;
-    if (!target.closest('[data-tauri-drag-region]')) {
+    
+    // 排除交互元素，避免影响按钮点击
+    if (target.closest('button') || target.closest('.titlebar-right') || target.closest('.titlebar-menu')) {
+      return;
+    }
+
+    // 只在拖动区域触发
+    if (!target.closest('[data-drag-region]')) {
       return;
     }
 
     try {
       const { getCurrentWindow } = await import('@tauri-apps/api/window');
-      await getCurrentWindow().startDragging();
+      const appWindow = getCurrentWindow();
+      
+      if (e.detail === 2) {
+        // 双击最大化/还原
+        await appWindow.toggleMaximize();
+      } else {
+        await appWindow.startDragging();
+      }
     } catch (err) {
       console.error('Failed to start dragging:', err);
     }
@@ -62,13 +108,13 @@
   }
 </script>
 
-<header class="titlebar" class:is-mac={isMac} class:is-win={isWin}>
-  <div class="titlebar-row top-row" data-tauri-drag-region on:mousedown={handleDrag}>
-    <div class="titlebar-left" data-tauri-drag-region>
+<header class="titlebar" class:is-mac={isMac} class:is-win={isWin} class:is-fullscreen={isFullscreen}>
+  <div class="titlebar-row top-row" data-drag-region on:mousedown={handleDrag}>
+    <div class="titlebar-left" data-drag-region>
       <span class="app-logo">M</span>
-      <span class="app-name" data-tauri-drag-region>NewMd</span>
+      <span class="app-name" data-drag-region>NewMd</span>
     </div>
-    <span class="titlebar-spacer" data-tauri-drag-region></span>
+    <span class="titlebar-spacer" data-drag-region></span>
     <div class="titlebar-right">
       <button class="icon-btn" title="切换主题" on:click={toggleTheme}>
         {#if theme === 'light'}

--- a/src/app/styles/app-responsive.css
+++ b/src/app/styles/app-responsive.css
@@ -58,15 +58,13 @@
   border-bottom: 1px dashed var(--md-titlebar-border);
 }
 
-.titlebar.is-mac .titlebar-row.top-row {
-  padding-left: 80px; /* 为 macOS 原生红绿灯留出空间 */
-  -webkit-app-region: drag;
+.titlebar.is-mac:not(.is-fullscreen) .titlebar-row.top-row {
+  padding-left: 80px; /* 为 macOS 原生红绿灯留出空间，全屏时不需要 */
 }
 
 .titlebar-row.bottom-row {
   height: 27px;
   padding: 0 12px;
-  -webkit-app-region: no-drag;
 }
 
 .titlebar-left {
@@ -103,7 +101,6 @@
 .titlebar-menu {
   display: flex;
   align-items: center;
-  -webkit-app-region: no-drag;
 }
 
 .menu-item {
@@ -163,7 +160,6 @@
     background 0.1s,
     color 0.1s;
   font-family: inherit;
-  -webkit-app-region: no-drag;
 }
 
 .dropdown-menu button:hover,
@@ -226,7 +222,6 @@
   display: flex;
   align-items: center;
   height: 100%;
-  -webkit-app-region: no-drag;
 }
 
 .titlebar-right .icon-btn {
@@ -252,7 +247,6 @@
   display: flex;
   height: 100%;
   align-items: center;
-  -webkit-app-region: no-drag;
 }
 
 .control-btn {
@@ -268,7 +262,6 @@
   transition:
     background 0.15s,
     color 0.15s;
-  -webkit-app-region: no-drag;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
1. 新增窗口拖拽和切换最大化的权限配置
2. 实现标题栏双击最大化/还原功能
3. 优化macOS全屏状态下的标题栏内边距
4. 移除冗余的-webkit-app-region拖拽配置，改用权限控制
5. 修复标题栏交互区域的点击拦截逻辑