### PR TITLE
refactor: 优化代码块与标题栏样式与交互

### DIFF
--- a/src/app/components/AppTitleBar.svelte
+++ b/src/app/components/AppTitleBar.svelte
@@ -34,6 +34,7 @@
   let isMac = false;
   let isWin = false;
   let isFullscreen = false;
+  let isMaximized = false;
   let unlistenResized: (() => void) | null = null;
 
   onMount(() => {
@@ -51,10 +52,19 @@
         appWindow.isFullscreen().then(fullscreen => {
           if (!isDestroyed) isFullscreen = fullscreen;
         });
+        appWindow.isMaximized().then(maximized => {
+          if (!isDestroyed) isMaximized = maximized;
+        });
 
         // 监听窗口改变事件
         appWindow.onResized(async () => {
-          if (!isDestroyed) isFullscreen = await appWindow.isFullscreen();
+          if (!isDestroyed) {
+            isFullscreen = await appWindow.isFullscreen();
+            // 在 Mac 上双击 topbar 放大其实是 zoom，但原生的红绿灯还在！
+            // 所以即使 isMaximized 变成了 true，我们也不应该去掉 80px 的左内边距。
+            // 只有 isFullscreen 才会让红绿灯消失。
+            isMaximized = await appWindow.isMaximized();
+          }
         }).then(unlisten => {
           if (isDestroyed) {
             unlisten();

--- a/src/app/services/settings.ts
+++ b/src/app/services/settings.ts
@@ -1,4 +1,5 @@
 import { listAppSettings, updateAppSetting } from '../../lib/desktop/tauriStorage';
+import { CodeBlockNodeView } from '../../lib/editor-core/nodeViews/CodeBlockNodeView';
 
 export interface PersistedEditorSettings {
   theme?: 'light' | 'dark';
@@ -53,6 +54,8 @@ export function persistEditorSetting(desktopEnabled: boolean, key: string, value
 
 export function applyThemeSetting(theme: 'light' | 'dark') {
   document.documentElement.dataset.theme = theme === 'dark' ? 'dark' : '';
+  // 通知代码块更新语法高亮主题
+  CodeBlockNodeView.updateTheme();
 }
 
 export function applyTypographySettings(fontSize: number, lineHeight: number) {

--- a/src/app/styles/app-responsive.css
+++ b/src/app/styles/app-responsive.css
@@ -58,6 +58,10 @@
   border-bottom: 1px dashed var(--md-titlebar-border);
 }
 
+.titlebar.is-mac .titlebar-row.top-row {
+  transition: padding-left 0.15s;
+}
+
 .titlebar.is-mac:not(.is-fullscreen) .titlebar-row.top-row {
   padding-left: 80px; /* 为 macOS 原生红绿灯留出空间，全屏时不需要 */
 }

--- a/src/app/styles/editor-document.css
+++ b/src/app/styles/editor-document.css
@@ -289,10 +289,7 @@
   color: var(--md-editor-blockquote-fg);
 }
 
-.code-card,
-.mermaid-block,
-.math-block,
-.html-block {
+.code-card {
   --code-gutter-width: 32px;
   --code-content-padding-left: 12px;
   --code-content-padding-right: 16px;
@@ -302,7 +299,7 @@
   margin: 18px 0;
   border: 1px solid var(--md-editor-code-border);
   border-radius: var(--md-editor-radius-md);
-  background: color-mix(in srgb, var(--md-editor-code-bg) 94%, #ffffff 6%);
+  background: var(--md-editor-code-bg);
   color: var(--md-editor-code-fg);
 }
 
@@ -657,6 +654,8 @@
 .math-block,
 .html-block {
   padding: 16px;
+  margin: 18px 0;
+  border-radius: var(--md-editor-radius-md);
   overflow-x: auto;
   background: color-mix(in srgb, var(--md-editor-table-header-bg) 76%, var(--md-editor-surface));
   color: var(--md-editor-fg);
@@ -1112,4 +1111,9 @@
 [data-theme='dark'] .inline-code-token-operator,
 .dark .inline-code-token-operator {
   color: #ff7b72;
+}
+
+[data-theme='dark'] .mermaid-block {
+  filter: invert(0.9) hue-rotate(180deg);
+  background: #fcfcfc; /* 翻转后变成深色，确保文字可见 */
 }

--- a/src/lib/editor-core/nodeViews/CodeBlockNodeView.ts
+++ b/src/lib/editor-core/nodeViews/CodeBlockNodeView.ts
@@ -240,6 +240,15 @@ export class CodeBlockNodeView {
     this.renderDisplay();
   }
 
+  static updateTheme(): void {
+    for (const instance of CodeBlockNodeView.instances) {
+      instance.renderDisplay();
+      if (instance.editing && instance.textarea && instance.highlightLayer) {
+        void instance.renderHighlightFor(instance.textarea.value, instance.language, instance.highlightLayer);
+      }
+    }
+  }
+
   // ---- NodeView 接口 ----
 
   update(node: ProseMirrorNode): boolean {
@@ -335,7 +344,7 @@ export class CodeBlockNodeView {
     }
     // 根据当前主题选择 Shiki 主题
     const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    const theme = isDark ? 'dark' : 'github-light';
+    const theme = isDark ? 'github-dark' : 'github-light';
     try {
       const result = await codeTokenizer.tokenize({
         code,


### PR DESCRIPTION
1. 调整macOS标题栏左内边距的过渡动画
2. 修复代码块主题切换逻辑，更新shiki暗色主题为github-dark
3. 新增全局更新代码块高亮主题的方法
4. 优化代码块、图表等区块的样式统一
5. 修复macOS窗口最大化时的标题栏内边距问题